### PR TITLE
Return user object from createDrupalUser so that loginCreatedUser can…

### DIFF
--- a/src/Context/User/UserContext.php
+++ b/src/Context/User/UserContext.php
@@ -30,7 +30,7 @@ class UserContext extends RawUserContext
      */
     public function loginCreatedUser($roles, TableNode $fields = null)
     {
-        $this->createDrupalUser($roles, $fields);
+        $this->user = $this->createDrupalUser($roles, $fields);
         $this->loginUser();
     }
 
@@ -41,7 +41,7 @@ class UserContext extends RawUserContext
      */
     public function createDrupalUser($roles, TableNode $fields = null)
     {
-        $this->createUserWithRoles($roles, null !== $fields ? $fields->getRowsHash() : []);
+        return $this->createUserWithRoles($roles, null !== $fields ? $fields->getRowsHash() : []);
     }
 
     /**


### PR DESCRIPTION
When I'm trying to use a case:

```
Given I am logged in as a user with "authenticated user" role and filled fields:
      | First Name               | Tester            |
      | Last Name                | McTesterson       |
      | Country                  | Testerland        |
      | Company Name             | TesterCorp        |
```

I receive a error - Tried to login without a user. (Exception) .
For fixing it loginCreatedUser and createDrupalUser has been modified to return user object and assign it to $this->user
