### PR TITLE
Add node context to facilitate node operations

### DIFF
--- a/src/Context/Node/NodeContext.php
+++ b/src/Context/Node/NodeContext.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @author Sergii Bondarenko, <sb@firstvector.org>
+ */
+namespace Drupal\TqExtension\Context\Node;
+
+use Drupal\TqExtension\Context\RawTqContext;
+
+class NodeContext extends RawTqContext
+{
+    /**
+     * @When /^I (visit|view|edit) "([^"]+)" node of type "([^"]+)"$/
+     */
+    public function iVisitNodePageOfType($operation, $title, $type) {
+        if ($operation == 'visit') {
+            $operation = 'view';
+        }
+        $query = new \EntityFieldQuery();
+        $result = $query
+            ->entityCondition('entity_type', 'node')
+            // @todo: Add support for CT label.
+            ->entityCondition('bundle', strtolower($type))
+            ->propertyCondition('title', $title)
+            ->range(0, 1)
+            ->execute();
+
+        if (empty($result['node'])) {
+            $params = array(
+                '@title' => $title,
+                '@type' => $type,
+            );
+            throw new \Exception(format_string("Node @title of @type not found.", $params));
+        }
+
+        $nid = key($result['node']);
+        $this->getSession()->visit($this->locatePath('/node/' . $nid . '/' . $operation));
+    }
+
+    /**
+     * @When I edit this node
+     */
+    public function iEditThisNode()
+    {
+        if (preg_match("@node/(\d+)@", $_GET['q'], $matches)) {
+            $this->getSession()->visit($this->locatePath('/node/' . $matches[1] . '/edit'));
+        }
+        else {
+            throw new \Exception("You're not currently on a node page.");
+        }
+    }
+}

--- a/src/Context/Node/RawNodeContext.php
+++ b/src/Context/Node/RawNodeContext.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @author Cristina Eftimita, <eftimitac@gmail.com>
+ */
+namespace Drupal\TqExtension\Context\Node;
+
+// Contexts.
+use Drupal\TqExtension\Context\RawTqContext;
+
+class RawNodeContext extends RawTqContext
+{
+    /**
+     * Retrieves node nid by node title and type.
+     * @param $title
+     *   Node title to lookup, accepts exact match only.
+     * @param $type
+     *   Node type machine name.
+     * @return int|null
+     *   Returns node nid if found.
+     * @throws \Exception
+     */
+    public function getNodeIdByTitle($title, $type)
+    {
+        $nid = db_select('node', 'n')
+            ->fields('n', array('nid'))
+            ->condition('n.title', $title)
+            ->condition('n.type', $type)
+            ->range(0, 1)
+            ->execute()->fetchField();
+
+        if (empty($nid)) {
+            throw new \Exception(sprintf("Node %s of %s not found.", $title, $type));
+        }
+        return $nid;
+    }
+}

--- a/src/Context/TqContext.php
+++ b/src/Context/TqContext.php
@@ -261,6 +261,8 @@ class TqContext extends RawTqContext
     public function beforeStep(BehatScope\StepScope $scope)
     {
         self::$pageUrl = $this->getCurrentUrl();
+        // To allow Drupal use its internal, web-based functionality, such as "arg()" or "current_path()" etc.
+        $_GET['q'] = ltrim(parse_url(static::$pageUrl)['path'], '/');
     }
 
     /**


### PR DESCRIPTION
In case of creating multiple nodes needed a step to review one of these pages 
Example of usage: 

```
 Scenario: Related articles block 
    Given "article" content:
      | title | status | related_articles |
      | A1   | 1      | A2             |
      | A2   | 1      | none             |

    When I view "A1" node of type "article"
    Then I should see the text "A2"
    When I view "A2" node of type "article"
    Then I should not see the text "A1"
```
