### PR TITLE
Change $_GET['q'] to use internal path instead of alias

### DIFF
--- a/src/Context/TqContext.php
+++ b/src/Context/TqContext.php
@@ -262,7 +262,11 @@ class TqContext extends RawTqContext
     {
         self::$pageUrl = $this->getCurrentUrl();
         // To allow Drupal use its internal, web-based functionality, such as "arg()" or "current_path()" etc.
-        $_GET['q'] = ltrim(parse_url(static::$pageUrl)['path'], '/');
+        $path = ltrim(parse_url(static::$pageUrl)['path'], '/');
+        if ('' == $path) {
+            $path = variable_get('site_frontpage', 'node');
+        }
+        $_GET['q'] = drupal_get_normal_path($path);
     }
 
     /**


### PR DESCRIPTION
Had a case when node/nid wasn't identified as a node page bc of $_GET['q'] being an alias

```
 Scenario: Training Series node page items
    Given I am on the "/article/title" page
    And I edit the node
    Then I should see the text "manage display"
```

Which was giving a response "Page "/article/title" is not a node. Unable to edit"
