### PR TITLE
Add uid to user object before sending it to userCreate

### DIFF
--- a/src/Context/User/RawUserContext.php
+++ b/src/Context/User/RawUserContext.php
@@ -127,6 +127,7 @@ class RawUserContext extends RawTqContext
         $random = $this->getRandom();
         $username = $random->name(8);
         $user = [
+            'uid' => 0,
             'name' => $username,
             'pass' => $random->name(16),
             'mail' => "$username@example.com",


### PR DESCRIPTION
I have a situation where I am checking $user->uid in hook_user_presave, knowing that in drupal every $user object has the property uid. Even the anonymous has it:

```
function drupal_anonymous_user() {
  $user = variable_get('drupal_anonymous_user_object', new stdClass);
  $user->uid = 0;
  $user->hostname = ip_address();
  $user->roles = array();
  $user->roles[DRUPAL_ANONYMOUS_RID] = 'anonymous user';
  $user->cache = 0;
  return $user;
}
```

And this function is used to create the user as in `user_register_form` :

```
$form['#user'] = drupal_anonymous_user();
```
