### PR TITLE
Add step to go to user page or user edit page with specified mail or name

### DIFF
--- a/src/Context/User/RawUserContext.php
+++ b/src/Context/User/RawUserContext.php
@@ -188,4 +188,31 @@ class RawUserContext extends RawTqContext
 
         return $user;
     }
+
+    /**
+     * Retrieves user by given property.
+     *
+     * @param $column
+     *   User property, name or mail, to look for.
+     * @param $value
+     *   The value to search for in the given column.
+     *
+     * @return int|null
+     *   Returns user uid if found.
+     *
+     * @throws \Exception
+     */
+    public function getUserByColumn($column, $value)
+    {
+        $uid = db_select('users', 'u')
+          ->fields('u', array('uid'))
+          ->condition('u.' . $column, '%' . db_like($value) . '%', 'LIKE')
+          ->range(0, 1)
+          ->execute()->fetchField();
+
+        if (empty($uid)) {
+            throw new \Exception(sprintf("User with the %s: %s not found.", $column, $value));
+        }
+        return $uid;
+    }
 }

--- a/src/Context/User/UserContext.php
+++ b/src/Context/User/UserContext.php
@@ -72,6 +72,30 @@ class UserContext extends RawUserContext
     }
 
     /**
+     * @param $operation
+     *   The operation applied on the user: view or edit.
+     * @param $column
+     *   The column in users table into which the value will be searched.
+     * @param $value
+     *   The value to search in users table.
+     *
+     * @throws \Exception
+     *   When user not found.
+     *
+     * @When /^I (visit|view|edit) user with (name|mail) "([^"]+)"$/
+     */
+    public function visitUser($operation, $column, $value)
+    {
+        if ('visit' === $operation) {
+            $operation = 'view';
+        }
+
+        $uid = $this->getUserByColumn($column, $value);
+
+        $this->getRedirectContext()->visitPage("user/$uid/$operation");
+    }
+
+    /**
      * @AfterScenario
      */
     public function afterUserScenario() {


### PR DESCRIPTION
Add a new step to visit a user page or user edit page to check for specific fields.

How to use:

```
And I create a user with "authenticated user" role and filled fields:
      | mail                   | user@example.com  |
      | name                   | username          |
When I edit user with mail "user@example.com"
```

or

```
When I visit user with name "username"
```

In the first case, it will search for user with that mail and go to user/UID/edit page
In the second case, it will search for user with that name and go to page user/UID/view which is the user page
