### PR TITLE
Change getIdByArguments visibility to public. 

### DIFF
--- a/src/Context/Node/RawNodeContext.php
+++ b/src/Context/Node/RawNodeContext.php
@@ -32,7 +32,7 @@ class RawNodeContext extends RawTqContext
      *
      * @throws \InvalidArgumentException
      */
-    protected function getIdByArguments($title, $contentType = '')
+    public function getIdByArguments($title, $contentType = '')
     {
         $nid = new FetchField('node', 'nid');
         $nid->condition('title', "$title%", 'like');

--- a/src/Context/RawTqContext.php
+++ b/src/Context/RawTqContext.php
@@ -24,6 +24,7 @@ use Drupal\TqExtension\Utils\Tags;
  * @see RawTqContext::__call()
  *
  * @method User\UserContext getUserContext()
+ * @method Node\NodeContext getNodeContext()
  * @method Form\FormContext getFormContext()
  * @method Email\EmailContext getEmailContext()
  * @method Drush\DrushContext getDrushContext()

--- a/src/Context/User/RawUserContext.php
+++ b/src/Context/User/RawUserContext.php
@@ -26,7 +26,7 @@ class RawUserContext extends RawTqContext
     /**
      * {@inheritdoc}
      */
-    protected function getCurrentId()
+    public function getCurrentId()
     {
         return empty($this->user->uid) ? 0 : $this->user->uid;
     }
@@ -39,7 +39,7 @@ class RawUserContext extends RawTqContext
      *
      * @return int
      */
-    protected function getIdByArguments($column, $value)
+    public function getIdByArguments($column, $value)
     {
         return (new FetchField('users', 'uid'))
             ->condition($column, $value)

--- a/src/Utils/BaseEntity.php
+++ b/src/Utils/BaseEntity.php
@@ -26,14 +26,14 @@ trait BaseEntity
      * @return int
      *   An ID of the entity.
      */
-    abstract protected function getIdByArguments($argument1, $argument2);
+    abstract public function getIdByArguments($argument1, $argument2);
 
     /**
      * Get identifier of current entity.
      *
      * @return int
      */
-    protected function getCurrentId()
+    public function getCurrentId()
     {
         // We have programmatically bootstrapped Drupal core, so able to use such functionality.
         $args = arg();
@@ -52,7 +52,7 @@ trait BaseEntity
      * @return string
      *   Entity URL.
      */
-    protected function entityUrl($operation, $argument1 = '', $argument2 = '')
+    public function entityUrl($operation, $argument1 = '', $argument2 = '')
     {
         if ('visit' === $operation) {
             $operation = 'view';


### PR DESCRIPTION
**Problem:**
When working with TqExtension in custom FeatureContext, as a developer I want to reuse as much helper methods implemented in TqExtension as possible to follow DRY. Currently helper methods defined in NodeContext and UserContext derived from BaseEntity are not accessible from non BaseEntity class hierarchy, this make reusing methods impossible and brings no value as API for other steps, other than TqExtension Contexts.

The scope is to use the TqExtension methods from RawContext classes as a low-level API. 

For example, I was implementing a step that will flag a node by node title. This will require id and entity_type to work. Using your function will help keep the code DRY and reusable. I ended up using something like this 

```
$nid = $this->getNodeContext()->getIdByArguments($node_title, $type);
$flag->flag($action, $nid);
```

**Proposed solution:**
For start we can change method visibility to public to allow other classes to benefit from those.
