### PR TITLE
Fix warning

### DIFF
--- a/src/Context/User/RawUserContext.php
+++ b/src/Context/User/RawUserContext.php
@@ -147,7 +147,6 @@ class RawUserContext extends RawTqContext
     {
         if ($this->isLoggedIn()) {
             $this->logout();
-            $this->user = false;
         }
     }
 


### PR DESCRIPTION
Interacting directly with the RawDrupalContext::$user property has been deprecated. Use RawDrupalContext::getUserManager->setCurrentUser() instead.

It'll be done inside logout function.